### PR TITLE
Added return type to support cache utilization

### DIFF
--- a/query.proto
+++ b/query.proto
@@ -145,7 +145,7 @@ message QueryResponse {
     string error = 1;
   }
 
-  message ComponentsNotFoundOrInCache {
+  message ComponentsNotInCache {
 
   }
 
@@ -162,7 +162,7 @@ message QueryResponse {
     ModelFailure model = 99;
     Success success = 100;
     Error error = 101;
-    ComponentsNotFoundOrInCache componentsNotFoundOrInCache = 102;
+    ComponentsNotInCache componentsNotInCache = 102;
   }
 
   message Information {

--- a/query.proto
+++ b/query.proto
@@ -145,7 +145,7 @@ message QueryResponse {
     string error = 1;
   }
 
-  message ComponentNotFoundOrInCache {
+  message ComponentsNotFoundOrInCache {
 
   }
 
@@ -162,7 +162,7 @@ message QueryResponse {
     ModelFailure model = 99;
     Success success = 100;
     Error error = 101;
-    ComponentNotFoundOrInCache componentNotFoundOrInCache = 102;
+    ComponentsNotFoundOrInCache componentsNotFoundOrInCache = 102;
   }
 
   message Information {

--- a/query.proto
+++ b/query.proto
@@ -22,7 +22,7 @@ message QueryRequest {
   message Settings {
     bool disable_clock_reduction = 1;
   }
-  
+
   Settings settings = 6;
 }
 
@@ -125,24 +125,28 @@ message QueryResponse {
       enum Failure {
         UNREACHABLE = 0;
       }
-      
+
       Failure failure = 1;
   }
 
   message ReachabilityPath {
     Path path = 4;
   }
-  
+
   message Success {
 
   }
-  
+
   message Error {
     string error = 1;
   }
 
   message ParsingError {
     string error = 1;
+  }
+
+  message ComponentNotFoundOrInCache {
+
   }
 
   oneof result {
@@ -153,11 +157,12 @@ message QueryResponse {
     ReachabilityFailure reachability = 6;
     RefinementFailure refinement = 7;
     ReachabilityPath reachability_path = 8;
-    
+
     ParsingError parsing_error = 98;
     ModelFailure model = 99;
     Success success = 100;
     Error error = 101;
+    ComponentNotFoundOrInCache componentNotFoundOrInCache = 102;
   }
 
   message Information {


### PR DESCRIPTION
This PR adds the result type `ComponentsNotInCache` needed by https://github.com/ECDAR-AAU-SW-P5/Reveaal/pull/10

@ECDAR-AAU-SW-P5/group2 