### PR TITLE
Ecdar-API Services and Message types (group 1 & 2)

### DIFF
--- a/api.proto
+++ b/api.proto
@@ -18,7 +18,8 @@ message GetAuthTokenRequest {
 }
 
 message GetAuthTokenResponse {
-    string token = 1;
+    string access_token = 1;
+    string refresh_token = 2;
 }
 
 message DeleteUserRequest {

--- a/api.proto
+++ b/api.proto
@@ -20,3 +20,13 @@ message GetAuthTokenRequest {
 message GetAuthTokenResponse {
     string token = 1;
 }
+
+message CreateUserRequest {
+    string username = 1;
+    string email = 2;
+    string password = 3;
+}
+
+message CreateUserResponse {
+    string token = 1;
+}

--- a/api.proto
+++ b/api.proto
@@ -35,3 +35,11 @@ message CreateUserRequest {
 message CreateUserResponse {
     string token = 1;
 }
+
+message UpdateUserRequest {
+    string token = 1;
+    optional string username = 2;
+    optional string email = 3;
+    optional string password = 4;
+}
+

--- a/api.proto
+++ b/api.proto
@@ -66,3 +66,7 @@ message UpdateAccessRequest {
 message DeleteAccessRequest {
     int32 id = 1;
 }
+
+message DeleteModelRequest {
+    int32 id = 1;
+}

--- a/api.proto
+++ b/api.proto
@@ -66,3 +66,27 @@ message UpdateAccessRequest {
 message DeleteAccessRequest {
     int32 id = 1;
 }
+
+message Model {
+    int32 id = 1;
+    string name = 2;
+    ComponentsInfo components_info = 3;
+    int32 owner_id = 4;
+}
+
+message Query {
+    int32 id = 1;
+    int32 model_id = 2;
+    string query = 3;
+    string result = 4;
+    bool outdated = 5;
+}
+
+message GetModelRequest {
+    int32 id = 1;
+}
+
+message GetModelResponse {
+    Model model = 1;
+    repeated Query queries = 2;
+}

--- a/api.proto
+++ b/api.proto
@@ -37,3 +37,9 @@ message UpdateUserRequest {
     optional string email = 2;
     optional string password = 3;
 }
+
+message CreateAccessRequest{
+    string role = 1;
+    uint32 model_id = 2;
+    uint32 user_id = 3;
+}

--- a/api.proto
+++ b/api.proto
@@ -100,7 +100,9 @@ message GetModelRequest {
 message GetModelResponse {
     Model model = 1;
     repeated Query queries = 2;
+    bool in_use = 3;
 }
+
 message DeleteModelRequest {
     int32 id = 1;
 }

--- a/api.proto
+++ b/api.proto
@@ -33,8 +33,7 @@ message CreateUserRequest {
 }
 
 message UpdateUserRequest {
-    string token = 1;
-    optional string username = 2;
-    optional string email = 3;
-    optional string password = 4;
+    optional string username = 1;
+    optional string email = 2;
+    optional string password = 3;
 }

--- a/api.proto
+++ b/api.proto
@@ -128,12 +128,12 @@ message ListAccessInfoRequest {
 }
 
 message ListAccessInfoResponse {
-    repeated AccessInfo access_info = 1;
+    repeated AccessInfo AccessInfoList = 1;
 }
 
 message AccessInfo {
     int32 id = 1;
-    string role = 2;
-    int32 model_id = 3;
-    int32 user_id = 4;
+    int32 model_id = 2;
+    int32 user_id = 3;
+    string role = 4;
 }

--- a/api.proto
+++ b/api.proto
@@ -39,15 +39,15 @@ message UpdateUserRequest {
     optional string password = 3;
 }
 
-message ListModelsInfoResponse {
-    repeated ModelInfo ModelInfoList = 1;
+message ListProjectsInfoResponse {
+    repeated ProjectInfo ProjectInfoList = 1;
 }
 
-message ModelInfo {
-    int32 model_id = 1;
-    string model_name = 2;
-    int32 model_owner_id = 3;
-    string user_role_on_model = 4;
+message ProjectInfo {
+    int32 project_id = 1;
+    string project_name = 2;
+    int32 project_owner_id = 3;
+    string user_role_on_project = 4;
 }
 
 message UpdateQueryRequest {
@@ -57,7 +57,7 @@ message UpdateQueryRequest {
 
 message CreateQueryRequest {
     string string = 1;
-    int32 model_id = 2;
+    int32 project_id = 2;
 }
 
 message DeleteQueryRequest {
@@ -66,7 +66,7 @@ message DeleteQueryRequest {
 
 message SendQueryRequest {
     int32 id = 1;
-    int32 model_id = 2;
+    int32 project_id = 2;
 }
 
 message SendQueryResponse {
@@ -75,7 +75,7 @@ message SendQueryResponse {
 
 message CreateAccessRequest{
     string role = 1;
-    int32 model_id = 2;
+    int32 project_id = 2;
     int32 user_id = 3;
 }
 
@@ -88,7 +88,7 @@ message DeleteAccessRequest {
     int32 id = 1;
 }
 
-message Model {
+message Project {
     int32 id = 1;
     string name = 2;
     ComponentsInfo components_info = 3;
@@ -97,36 +97,36 @@ message Model {
 
 message Query {
     int32 id = 1;
-    int32 model_id = 2;
+    int32 project_id = 2;
     string query = 3;
     string result = 4;
     bool outdated = 5;
 }
 
-message GetModelRequest {
+message GetProjectRequest {
     int32 id = 1;
 }
 
-message GetModelResponse {
-    Model model = 1;
+message GetProjectResponse {
+    Project project = 1;
     repeated Query queries = 2;
     bool in_use = 3;
 }
 
-message DeleteModelRequest {
+message DeleteProjectRequest {
     int32 id = 1;
 }
 
-message CreateModelRequest {
+message CreateProjectRequest {
     string name = 1;
     ComponentsInfo components_info = 2;
 }
 
-message CreateModelResponse {
+message CreateProjectResponse {
     int32 id = 1;
 }
 
-message UpdateModelRequest {
+message UpdateProjectRequest {
     int32 id = 1;
     optional string name = 2;
     optional ComponentsInfo components_info = 3;

--- a/api.proto
+++ b/api.proto
@@ -37,3 +37,10 @@ message UpdateUserRequest {
     optional string email = 2;
     optional string password = 3;
 }
+
+message UpdateQueryRequest {
+    optional string string = 1;
+    optional int32 model_id = 2;
+    optional string result = 3;
+    optional bool outdated = 4;
+}

--- a/api.proto
+++ b/api.proto
@@ -80,3 +80,10 @@ message CreateModelRequest {
 message CreateModelResponse {
     int32 id = 1;
 }
+
+message UpdateModelRequest {
+    int32 id = 1;
+    optional string name = 2;
+    optional ComponentsInfo components_info = 3;
+    optional int32 owner_id = 4;
+}

--- a/api.proto
+++ b/api.proto
@@ -10,17 +10,17 @@ import "component.proto";
 import "objects.proto";
 import "query.proto";
 
-message GetAuthTokenRequest { 
-    optional UserCredentials user_credentials = 1; 
- 
-    message UserCredentials { 
-        oneof user { 
-            string username = 1; 
-            string email = 2; 
-        } 
-        string password = 3; 
-    } 
-} 
+message GetAuthTokenRequest {
+    optional UserCredentials user_credentials = 1;
+
+    message UserCredentials {
+        oneof user {
+            string username = 1;
+            string email = 2;
+        }
+        string password = 3;
+    }
+}
 
 message GetAuthTokenResponse {
     string access_token = 1;
@@ -131,4 +131,8 @@ message UpdateProjectRequest {
     optional string name = 2;
     optional ComponentsInfo components_info = 3;
     optional int32 owner_id = 4;
+}
+
+message EndpointsResponse {
+	repeated string endpoints = 1;
 }

--- a/api.proto
+++ b/api.proto
@@ -8,6 +8,7 @@ option java_outer_classname = "ApiProtos";
 
 import "component.proto";
 import "objects.proto";
+import "query.proto";
 
 message GetAuthTokenRequest { 
     optional UserCredentials user_credentials = 1; 
@@ -61,6 +62,15 @@ message CreateQueryRequest {
 
 message DeleteQueryRequest {
     int32 id = 1;
+}
+
+message SendQueryRequest {
+    int32 id = 1;
+    int32 model_id = 2;
+}
+
+message SendQueryResponse {
+    QueryResponse response = 1;
 }
 
 message CreateAccessRequest{

--- a/api.proto
+++ b/api.proto
@@ -9,13 +9,20 @@ option java_outer_classname = "ApiProtos";
 import "component.proto";
 import "objects.proto";
 
-message GetAuthTokenRequest {
-    oneof user {
-        string username = 1;
-        string email = 2;
-    }
-    string password = 3;
-}
+message GetAuthTokenRequest { 
+    oneof auth_option { 
+        UserCredentials user_credentials = 1; 
+        string refresh_token = 2; 
+    } 
+ 
+    message UserCredentials { 
+        oneof user { 
+            string username = 1; 
+            string email = 2; 
+        } 
+        string password = 3; 
+    } 
+} 
 
 message GetAuthTokenResponse {
     string access_token = 1;

--- a/api.proto
+++ b/api.proto
@@ -10,10 +10,7 @@ import "component.proto";
 import "objects.proto";
 
 message GetAuthTokenRequest { 
-    oneof auth_option { 
-        UserCredentials user_credentials = 1; 
-        string refresh_token = 2; 
-    } 
+    optional UserCredentials user_credentials = 1; 
  
     message UserCredentials { 
         oneof user { 
@@ -27,11 +24,6 @@ message GetAuthTokenRequest {
 message GetAuthTokenResponse {
     string access_token = 1;
     string refresh_token = 2;
-}
-
-message DeleteUserRequest {
-    string token = 1;
-
 }
 
 message CreateUserRequest {

--- a/api.proto
+++ b/api.proto
@@ -37,3 +37,14 @@ message UpdateUserRequest {
     optional string email = 2;
     optional string password = 3;
 }
+
+message ListAccessInfoResponse {
+    repeated AccessInfo AccessInfoList = 1;
+}
+
+message AccessInfo {
+    int32 id = 1;
+    string role = 2;
+    int32 model_id = 3;
+    int32 user_id = 4;
+}

--- a/api.proto
+++ b/api.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package EcdarProtoBuf;
+
+option java_multiple_files = false;
+option java_package = "EcdarProtoBuf";
+option java_outer_classname = "ApiProtos";
+
+import "component.proto";
+import "objects.proto";
+
+message GetAuthTokenRequest {
+    oneof user {
+        string username = 1;
+        string email = 2;
+    }
+    string password = 3;
+}
+
+message GetAuthTokenResponse {
+    string token = 1;
+}

--- a/api.proto
+++ b/api.proto
@@ -37,3 +37,7 @@ message UpdateUserRequest {
     optional string email = 2;
     optional string password = 3;
 }
+
+message DeleteAccessRequest {
+    int32 access_id = 1;
+}

--- a/api.proto
+++ b/api.proto
@@ -37,3 +37,7 @@ message UpdateUserRequest {
     optional string email = 2;
     optional string password = 3;
 }
+
+message UpdateAccessRequest {
+    optional string role = 1;
+}

--- a/api.proto
+++ b/api.proto
@@ -66,7 +66,12 @@ message DeleteQueryRequest {
 message CreateAccessRequest{
     string role = 1;
     int32 model_id = 2;
-    int32 user_id = 3;
+    
+    oneof user {
+        int32 user_id = 3;
+        string username = 4;
+        string email = 5;
+    }
 }
 
 message UpdateAccessRequest {

--- a/api.proto
+++ b/api.proto
@@ -122,3 +122,18 @@ message UpdateModelRequest {
     optional ComponentsInfo components_info = 3;
     optional int32 owner_id = 4;
 }
+
+message ListAccessInfoRequest {
+    int32 model_id = 1;
+}
+
+message ListAccessInfoResponse {
+    repeated AccessInfo access_info = 1;
+}
+
+message AccessInfo {
+    int32 id = 1;
+    string role = 2;
+    int32 model_id = 3;
+    int32 user_id = 4;
+}

--- a/api.proto
+++ b/api.proto
@@ -38,15 +38,15 @@ message UpdateUserRequest {
     optional string password = 3;
 }
 
-message ListAccessInfoResponse {
-    repeated AccessInfo AccessInfoList = 1;
+message ListModelInfoResponse {
+    repeated ModelInfo ModelInfoList = 1;
 }
 
-message AccessInfo {
-    int32 id = 1;
-    string role = 2;
-    int32 model_id = 3;
-    int32 user_id = 4;
+message ModelInfo {
+    int32 model_id = 1;
+    string model_name = 2;
+    int32 model_owner_id = 3;
+    string user_role_on_model = 4;
 }
 
 message UpdateQueryRequest {
@@ -101,6 +101,7 @@ message GetModelResponse {
     Model model = 1;
     repeated Query queries = 2;
 }
+
 message DeleteModelRequest {
     int32 id = 1;
 }

--- a/api.proto
+++ b/api.proto
@@ -39,31 +39,30 @@ message UpdateUserRequest {
 }
 
 message UpdateQueryRequest {
-    optional string string = 1;
-    optional int32 model_id = 2;
-    optional string result = 3;
-    optional bool outdated = 4;
+    int32 id = 1;
+    string string = 2;
 }
 
 message CreateQueryRequest {
     string string = 1;
-    uint32 model_id = 2;
+    int32 model_id = 2;
 }
 
 message DeleteQueryRequest {
-    int32 query_id = 1;
+    int32 id = 1;
 }
 
 message CreateAccessRequest{
     string role = 1;
-    uint32 model_id = 2;
-    uint32 user_id = 3;
+    int32 model_id = 2;
+    int32 user_id = 3;
 }
 
 message UpdateAccessRequest {
-    optional string role = 1;
+    int32 id = 1;
+    string role = 2;
 }
 
 message DeleteAccessRequest {
-    int32 access_id = 1;
+    int32 id = 1;
 }

--- a/api.proto
+++ b/api.proto
@@ -38,7 +38,7 @@ message UpdateUserRequest {
     optional string password = 3;
 }
 
-message ListModelInfoResponse {
+message ListModelsInfoResponse {
     repeated ModelInfo ModelInfoList = 1;
 }
 

--- a/api.proto
+++ b/api.proto
@@ -66,3 +66,13 @@ message UpdateAccessRequest {
 message DeleteAccessRequest {
     int32 id = 1;
 }
+
+message CreateModelRequest {
+    string name = 1;
+    ComponentsInfo components_info = 2;
+    int32 owner_id = 3;
+}
+
+message CreateModelResponse {
+    int32 id = 1;
+}

--- a/api.proto
+++ b/api.proto
@@ -32,14 +32,9 @@ message CreateUserRequest {
     string password = 3;
 }
 
-message CreateUserResponse {
-    string token = 1;
-}
-
 message UpdateUserRequest {
     string token = 1;
     optional string username = 2;
     optional string email = 3;
     optional string password = 4;
 }
-

--- a/api.proto
+++ b/api.proto
@@ -32,6 +32,18 @@ message CreateUserRequest {
     string password = 3;
 }
 
+message GetUsersRequest {
+    repeated int32 ids = 1;
+}
+
+message GetUsersResponse {
+    message UserInfo {
+        int32 id = 1;
+        string username = 2;
+    }
+    repeated UserInfo users = 1;
+}
+
 message UpdateUserRequest {
     optional string username = 1;
     optional string email = 2;

--- a/api.proto
+++ b/api.proto
@@ -37,3 +37,8 @@ message UpdateUserRequest {
     optional string email = 2;
     optional string password = 3;
 }
+
+message CreateQueryRequest {
+    string string = 1;
+    uint32 model_id = 2;
+}

--- a/api.proto
+++ b/api.proto
@@ -128,7 +128,7 @@ message ListAccessInfoRequest {
 }
 
 message ListAccessInfoResponse {
-    repeated AccessInfo AccessInfoList = 1;
+    repeated AccessInfo access_info_list = 1;
 }
 
 message AccessInfo {

--- a/api.proto
+++ b/api.proto
@@ -74,7 +74,6 @@ message DeleteModelRequest {
 message CreateModelRequest {
     string name = 1;
     ComponentsInfo components_info = 2;
-    int32 owner_id = 3;
 }
 
 message CreateModelResponse {

--- a/api.proto
+++ b/api.proto
@@ -37,3 +37,7 @@ message UpdateUserRequest {
     optional string email = 2;
     optional string password = 3;
 }
+
+message DeleteQueryRequest {
+    int32 query_id = 1;
+}

--- a/api.proto
+++ b/api.proto
@@ -20,3 +20,7 @@ message GetAuthTokenRequest {
 message GetAuthTokenResponse {
     string token = 1;
 }
+
+message DeleteUserRequest {
+    string token = 1;
+}

--- a/services.proto
+++ b/services.proto
@@ -20,11 +20,11 @@ service EcdarBackend {
 }
 
 service EcdarApi {
-    rpc GetModel(GetModelRequest) returns (GetModelResponse);
-    rpc CreateModel(CreateModelRequest) returns (CreateModelResponse);
-    rpc UpdateModel(UpdateModelRequest) returns (google.protobuf.Empty);
-    rpc DeleteModel(DeleteModelRequest) returns (google.protobuf.Empty);
-    rpc ListModelsInfo(google.protobuf.Empty) returns (ListModelsInfoResponse);
+    rpc GetProject(GetProjectRequest) returns (GetProjectResponse);
+    rpc CreateProject(CreateProjectRequest) returns (CreateProjectResponse);
+    rpc UpdateProject(UpdateProjectRequest) returns (google.protobuf.Empty);
+    rpc DeleteProject(DeleteProjectRequest) returns (google.protobuf.Empty);
+    rpc ListProjectsInfo(google.protobuf.Empty) returns (ListProjectsInfoResponse);
 
     rpc CreateAccess(CreateAccessRequest) returns (google.protobuf.Empty);
     rpc UpdateAccess(UpdateAccessRequest) returns (google.protobuf.Empty);

--- a/services.proto
+++ b/services.proto
@@ -19,6 +19,7 @@ service EcdarBackend {
     rpc TakeSimulationStep(SimulationStepRequest) returns (SimulationStepResponse);
 }
 
+// API service, endpoints are protected and require a valid access token
 service EcdarApi {
     rpc GetModel(GetModelRequest) returns (GetModelResponse);
     rpc CreateModel(CreateModelRequest) returns (CreateModelResponse);
@@ -37,9 +38,15 @@ service EcdarApi {
     rpc UpdateQuery(UpdateQueryRequest) returns (google.protobuf.Empty);
     rpc DeleteQuery(DeleteQueryRequest) returns (google.protobuf.Empty);
     rpc SendQuery(SendQueryRequest) returns (SendQueryResponse);
+
+    // Logout the user by deleting their session identified by the access token
+    rpc DeleteSession(google.protobuf.Empty) returns (google.protobuf.Empty);
 }
 
 service EcdarApiAuth {
+    // Get a new access and refresh token using either a previous refresh token or user credentials
     rpc GetAuthToken(GetAuthTokenRequest) returns (GetAuthTokenResponse);
+
+    // Create a new user with username, email and password
     rpc CreateUser(CreateUserRequest) returns (google.protobuf.Empty);
 }

--- a/services.proto
+++ b/services.proto
@@ -42,4 +42,5 @@ service EcdarApi {
 service EcdarApiAuth {
     rpc GetAuthToken(GetAuthTokenRequest) returns (GetAuthTokenResponse);
     rpc CreateUser(CreateUserRequest) returns (google.protobuf.Empty);
+    rpc Endpoints(google.protobuf.Empty) returns (EndpointsResponse);
 }

--- a/services.proto
+++ b/services.proto
@@ -24,7 +24,7 @@ service EcdarApi {
     rpc CreateModel(CreateModelRequest) returns (CreateModelResponse);
     rpc UpdateModel(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc DeleteModel(DeleteModelRequest) returns (google.protobuf.Empty);
-    rpc ListAccessInfo(google.protobuf.Empty) returns (ListAccessInfoResponse);
+    rpc ListModelInfo(google.protobuf.Empty) returns (ListModelInfoResponse);
 
     rpc CreateAccess(CreateAccessRequest) returns (google.protobuf.Empty);
     rpc UpdateAccess(UpdateAccessRequest) returns (google.protobuf.Empty);

--- a/services.proto
+++ b/services.proto
@@ -24,7 +24,7 @@ service EcdarApi {
     rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
     rpc CreateModel(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc CreateAccess(google.protobuf.Empty) returns (google.protobuf.Empty);
-    rpc UpdateUser(google.protobuf.Empty) returns (google.protobuf.Empty);
+    rpc UpdateUser(UpdateUserRequest) returns (google.protobuf.Empty);
     rpc UpdateModel(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc UpdateAccess(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc DeleteUser(DeleteUserRequest) returns (google.protobuf.Empty);

--- a/services.proto
+++ b/services.proto
@@ -22,7 +22,7 @@ service EcdarBackend {
 service EcdarApi {
     rpc GetModel(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc CreateModel(google.protobuf.Empty) returns (google.protobuf.Empty);
-    rpc CreateAccess(google.protobuf.Empty) returns (google.protobuf.Empty);
+    rpc CreateAccess(CreateAccessRequest) returns (google.protobuf.Empty);
     rpc UpdateUser(UpdateUserRequest) returns (google.protobuf.Empty);
     rpc UpdateModel(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc UpdateAccess(google.protobuf.Empty) returns (google.protobuf.Empty);

--- a/services.proto
+++ b/services.proto
@@ -20,7 +20,6 @@ service EcdarBackend {
 }
 
 service EcdarApi {
-    rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
     // rpc DeleteUser(DeleteUserRequest) returns (DeleteUserResponse);
     // rpc UpdateUser(UpdateUserRequest) returns (UpdateUserResponse);
     // rpc SaveModel(SaveModelRequest) returns (SaveModelResponse);
@@ -34,4 +33,5 @@ service EcdarApi {
 
 service EcdarApiAuth {
     rpc GetAuthToken(GetAuthTokenRequest) returns (GetAuthTokenResponse);
+    rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
 }

--- a/services.proto
+++ b/services.proto
@@ -32,6 +32,7 @@ service EcdarApi {
 
     rpc UpdateUser(UpdateUserRequest) returns (google.protobuf.Empty);
     rpc DeleteUser(google.protobuf.Empty) returns (google.protobuf.Empty);
+    rpc GetUsers(GetUsersRequest) returns (GetUsersResponse);
 
     rpc CreateQuery(CreateQueryRequest) returns (google.protobuf.Empty);
     rpc UpdateQuery(UpdateQueryRequest) returns (google.protobuf.Empty);

--- a/services.proto
+++ b/services.proto
@@ -20,7 +20,7 @@ service EcdarBackend {
 }
 
 service EcdarApi {
-    rpc GetModel(google.protobuf.Empty) returns (google.protobuf.Empty);
+    rpc GetModel(GetModelRequest) returns (GetModelResponse);
     rpc CreateModel(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc UpdateModel(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc DeleteModel(google.protobuf.Empty) returns (google.protobuf.Empty);

--- a/services.proto
+++ b/services.proto
@@ -20,7 +20,7 @@ service EcdarBackend {
 }
 
 service EcdarApi {
-    // rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
+    rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
     // rpc DeleteUser(DeleteUserRequest) returns (DeleteUserResponse);
     // rpc UpdateUser(UpdateUserRequest) returns (UpdateUserResponse);
     // rpc SaveModel(SaveModelRequest) returns (SaveModelResponse);
@@ -29,6 +29,7 @@ service EcdarApi {
     // rpc AddUserToModel(AddUserToModelRequest) returns (AddUserToModelResponse);
     // rpc RemoveUserFromModel(RemoveUserFromModelRequest) returns (RemoveUserFromModelResponse);
     // rpc UpdateModelAccess(UpdateModelAccessRequest) returns (UpdateModelAccessResponse);
+
 }
 
 service EcdarApiAuth {

--- a/services.proto
+++ b/services.proto
@@ -23,9 +23,10 @@ service EcdarApi {
     rpc GetModel(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc CreateModel(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc CreateAccess(google.protobuf.Empty) returns (google.protobuf.Empty);
-    rpc UpdateUser(UpdateUserRequest) returns (google.protobuf.Empty);
-    rpc UpdateModel(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc UpdateAccess(google.protobuf.Empty) returns (google.protobuf.Empty);
+    rpc UpdateModel(google.protobuf.Empty) returns (google.protobuf.Empty);
+    rpc UpdateQuery(UpdateQueryRequest) returns (google.protobuf.Empty);
+    rpc UpdateUser(UpdateUserRequest) returns (google.protobuf.Empty);
     rpc DeleteUser(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc DeleteModel(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc DeleteAccess(google.protobuf.Empty) returns (google.protobuf.Empty);

--- a/services.proto
+++ b/services.proto
@@ -26,8 +26,8 @@ service EcdarApi {
     rpc UpdateProject(UpdateProjectRequest) returns (google.protobuf.Empty);
     rpc DeleteProject(DeleteProjectRequest) returns (google.protobuf.Empty);
     rpc ListProjectsInfo(google.protobuf.Empty) returns (ListProjectsInfoResponse);
-    rpc ListAccessInfo(ListAccessInfoRequest) returns (ListAccessInfoResponse);
 
+    rpc ListAccessInfo(ListAccessInfoRequest) returns (ListAccessInfoResponse);
     rpc CreateAccess(CreateAccessRequest) returns (google.protobuf.Empty);
     rpc UpdateAccess(UpdateAccessRequest) returns (google.protobuf.Empty);
     rpc DeleteAccess(DeleteAccessRequest) returns (google.protobuf.Empty);

--- a/services.proto
+++ b/services.proto
@@ -7,6 +7,7 @@ option java_package = "EcdarProtoBuf";
 option java_outer_classname = "ServiceProtos";
 
 import "query.proto";
+import "api.proto";
 
 import "google/protobuf/empty.proto";
 
@@ -16,4 +17,20 @@ service EcdarBackend {
 
     rpc StartSimulation(SimulationStartRequest) returns (SimulationStepResponse);
     rpc TakeSimulationStep(SimulationStepRequest) returns (SimulationStepResponse);
+}
+
+service EcdarApi {
+    // rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
+    // rpc DeleteUser(DeleteUserRequest) returns (DeleteUserResponse);
+    // rpc UpdateUser(UpdateUserRequest) returns (UpdateUserResponse);
+    // rpc SaveModel(SaveModelRequest) returns (SaveModelResponse);
+    // rpc LoadModel(LoadModelRequest) returns (LoadModelResponse);
+    // rpc SendQuery(UserQueryRequest) returns (UserQueryResponse);
+    // rpc AddUserToModel(AddUserToModelRequest) returns (AddUserToModelResponse);
+    // rpc RemoveUserFromModel(RemoveUserFromModelRequest) returns (RemoveUserFromModelResponse);
+    // rpc UpdateModelAccess(UpdateModelAccessRequest) returns (UpdateModelAccessResponse);
+}
+
+service EcdarApiAuth {
+    rpc GetAuthToken(GetAuthTokenRequest) returns (GetAuthTokenResponse);
 }

--- a/services.proto
+++ b/services.proto
@@ -30,6 +30,7 @@ service EcdarApi {
     rpc DeleteModel(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc DeleteAccess(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc ListModelsInfo(google.protobuf.Empty) returns (google.protobuf.Empty);
+    rpc CreateQuery(CreateQueryRequest) returns (google.protobuf.Empty);
 }
 
 service EcdarApiAuth {

--- a/services.proto
+++ b/services.proto
@@ -29,6 +29,7 @@ service EcdarApi {
     rpc DeleteUser(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc DeleteModel(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc DeleteAccess(google.protobuf.Empty) returns (google.protobuf.Empty);
+    rpc DeleteQuery(DeleteQueryRequest) returns (google.protobuf.Empty);
     rpc ListModelsInfo(google.protobuf.Empty) returns (google.protobuf.Empty);
 }
 

--- a/services.proto
+++ b/services.proto
@@ -36,9 +36,13 @@ service EcdarApi {
     rpc DeleteUser(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc GetUsers(GetUsersRequest) returns (GetUsersResponse);
 
+    // The three endpoints below are planned to be deprecated
+    // Query handling will become part of `UpdateProject`
     rpc CreateQuery(CreateQueryRequest) returns (google.protobuf.Empty);
     rpc UpdateQuery(UpdateQueryRequest) returns (google.protobuf.Empty);
     rpc DeleteQuery(DeleteQueryRequest) returns (google.protobuf.Empty);
+
+    // Same as `SendQuery` in the `EcdarBackend` service but also saves the result of the query in th DB
     rpc SendQuery(SendQueryRequest) returns (SendQueryResponse);
 
     // Logout the user by deleting their session identified by the access token

--- a/services.proto
+++ b/services.proto
@@ -24,7 +24,7 @@ service EcdarApi {
     rpc CreateModel(CreateModelRequest) returns (CreateModelResponse);
     rpc UpdateModel(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc DeleteModel(DeleteModelRequest) returns (google.protobuf.Empty);
-    rpc ListAccessInfo(google.protobuf.Empty) returns (ListModelsInfoResponse);
+    rpc ListAccessInfo(google.protobuf.Empty) returns (ListAccessInfoResponse);
 
     rpc CreateAccess(CreateAccessRequest) returns (google.protobuf.Empty);
     rpc UpdateAccess(UpdateAccessRequest) returns (google.protobuf.Empty);

--- a/services.proto
+++ b/services.proto
@@ -28,7 +28,7 @@ service EcdarApi {
     rpc UpdateAccess(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc DeleteUser(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc DeleteModel(google.protobuf.Empty) returns (google.protobuf.Empty);
-    rpc DeleteAccess(google.protobuf.Empty) returns (google.protobuf.Empty);
+    rpc DeleteAccess(DeleteAccessRequest) returns (google.protobuf.Empty);
     rpc ListModelsInfo(google.protobuf.Empty) returns (google.protobuf.Empty);
 }
 

--- a/services.proto
+++ b/services.proto
@@ -26,7 +26,7 @@ service EcdarApi {
     rpc UpdateUser(UpdateUserRequest) returns (google.protobuf.Empty);
     rpc UpdateModel(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc UpdateAccess(google.protobuf.Empty) returns (google.protobuf.Empty);
-    rpc DeleteUser(DeleteUserRequest) returns (google.protobuf.Empty);
+    rpc DeleteUser(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc DeleteModel(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc DeleteAccess(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc ListModelsInfo(google.protobuf.Empty) returns (google.protobuf.Empty);

--- a/services.proto
+++ b/services.proto
@@ -25,7 +25,7 @@ service EcdarApi {
     rpc CreateAccess(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc UpdateUser(UpdateUserRequest) returns (google.protobuf.Empty);
     rpc UpdateModel(google.protobuf.Empty) returns (google.protobuf.Empty);
-    rpc UpdateAccess(google.protobuf.Empty) returns (google.protobuf.Empty);
+    rpc UpdateAccess(UpdateAccessRequest) returns (google.protobuf.Empty);
     rpc DeleteUser(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc DeleteModel(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc DeleteAccess(google.protobuf.Empty) returns (google.protobuf.Empty);

--- a/services.proto
+++ b/services.proto
@@ -23,7 +23,7 @@ service EcdarApi {
     rpc GetModel(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc CreateModel(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc UpdateModel(google.protobuf.Empty) returns (google.protobuf.Empty);
-    rpc DeleteModel(google.protobuf.Empty) returns (google.protobuf.Empty);
+    rpc DeleteModel(DeleteModelRequest) returns (google.protobuf.Empty);
     rpc ListModelsInfo(google.protobuf.Empty) returns (google.protobuf.Empty);
 
     rpc CreateAccess(CreateAccessRequest) returns (google.protobuf.Empty);

--- a/services.proto
+++ b/services.proto
@@ -29,7 +29,7 @@ service EcdarApi {
     rpc DeleteUser(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc DeleteModel(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc DeleteAccess(google.protobuf.Empty) returns (google.protobuf.Empty);
-    rpc ListModelsInfo(google.protobuf.Empty) returns (google.protobuf.Empty);
+    rpc ListAccessInfo(google.protobuf.Empty) returns (ListModelsInfoResponse);
 }
 
 service EcdarApiAuth {

--- a/services.proto
+++ b/services.proto
@@ -24,7 +24,7 @@ service EcdarApi {
     rpc CreateModel(CreateModelRequest) returns (CreateModelResponse);
     rpc UpdateModel(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc DeleteModel(DeleteModelRequest) returns (google.protobuf.Empty);
-    rpc ListModelInfo(google.protobuf.Empty) returns (ListModelInfoResponse);
+    rpc ListModelsInfo(google.protobuf.Empty) returns (ListModelsInfoResponse);
 
     rpc CreateAccess(CreateAccessRequest) returns (google.protobuf.Empty);
     rpc UpdateAccess(UpdateAccessRequest) returns (google.protobuf.Empty);

--- a/services.proto
+++ b/services.proto
@@ -36,6 +36,7 @@ service EcdarApi {
     rpc CreateQuery(CreateQueryRequest) returns (google.protobuf.Empty);
     rpc UpdateQuery(UpdateQueryRequest) returns (google.protobuf.Empty);
     rpc DeleteQuery(DeleteQueryRequest) returns (google.protobuf.Empty);
+    rpc SendQuery(SendQueryRequest) returns (SendQueryResponse);
 }
 
 service EcdarApiAuth {

--- a/services.proto
+++ b/services.proto
@@ -20,15 +20,7 @@ service EcdarBackend {
 }
 
 service EcdarApi {
-    // rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
-    // rpc DeleteUser(DeleteUserRequest) returns (DeleteUserResponse);
-    // rpc UpdateUser(UpdateUserRequest) returns (UpdateUserResponse);
-    // rpc SaveModel(SaveModelRequest) returns (SaveModelResponse);
-    // rpc LoadModel(LoadModelRequest) returns (LoadModelResponse);
-    // rpc SendQuery(UserQueryRequest) returns (UserQueryResponse);
-    // rpc AddUserToModel(AddUserToModelRequest) returns (AddUserToModelResponse);
-    // rpc RemoveUserFromModel(RemoveUserFromModelRequest) returns (RemoveUserFromModelResponse);
-    // rpc UpdateModelAccess(UpdateModelAccessRequest) returns (UpdateModelAccessResponse);
+    rpc DeleteUser(DeleteUserRequest) returns (google.protobuf.Empty);
 }
 
 service EcdarApiAuth {

--- a/services.proto
+++ b/services.proto
@@ -21,7 +21,7 @@ service EcdarBackend {
 
 service EcdarApi {
     rpc GetModel(google.protobuf.Empty) returns (google.protobuf.Empty);
-    rpc CreateModel(google.protobuf.Empty) returns (google.protobuf.Empty);
+    rpc CreateModel(CreateModelRequest) returns (CreateModelResponse);
     rpc UpdateModel(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc DeleteModel(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc ListModelsInfo(google.protobuf.Empty) returns (google.protobuf.Empty);

--- a/services.proto
+++ b/services.proto
@@ -20,17 +20,17 @@ service EcdarBackend {
 }
 
 service EcdarApi {
-    rpc DeleteUser(DeleteUserRequest) returns (google.protobuf.Empty);
+    rpc GetModel(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
-    // rpc DeleteUser(DeleteUserRequest) returns (DeleteUserResponse);
-    // rpc UpdateUser(UpdateUserRequest) returns (UpdateUserResponse);
-    // rpc SaveModel(SaveModelRequest) returns (SaveModelResponse);
-    // rpc LoadModel(LoadModelRequest) returns (LoadModelResponse);
-    // rpc SendQuery(UserQueryRequest) returns (UserQueryResponse);
-    // rpc AddUserToModel(AddUserToModelRequest) returns (AddUserToModelResponse);
-    // rpc RemoveUserFromModel(RemoveUserFromModelRequest) returns (RemoveUserFromModelResponse);
-    // rpc UpdateModelAccess(UpdateModelAccessRequest) returns (UpdateModelAccessResponse);
-
+    rpc CreateModel(google.protobuf.Empty) returns (google.protobuf.Empty);
+    rpc CreateAccess(google.protobuf.Empty) returns (google.protobuf.Empty);
+    rpc UpdateUser(google.protobuf.Empty) returns (google.protobuf.Empty);
+    rpc UpdateModel(google.protobuf.Empty) returns (google.protobuf.Empty);
+    rpc UpdateAccess(google.protobuf.Empty) returns (google.protobuf.Empty);
+    rpc DeleteUser(DeleteUserRequest) returns (google.protobuf.Empty);
+    rpc DeleteModel(google.protobuf.Empty) returns (google.protobuf.Empty);
+    rpc DeleteAccess(google.protobuf.Empty) returns (google.protobuf.Empty);
+    rpc ListModelsInfo(google.protobuf.Empty) returns (google.protobuf.Empty);
 }
 
 service EcdarApiAuth {

--- a/services.proto
+++ b/services.proto
@@ -25,6 +25,7 @@ service EcdarApi {
     rpc UpdateModel(UpdateModelRequest) returns (google.protobuf.Empty);
     rpc DeleteModel(DeleteModelRequest) returns (google.protobuf.Empty);
     rpc ListModelsInfo(google.protobuf.Empty) returns (ListModelsInfoResponse);
+    rpc ListAccessInfo(ListAccessInfoRequest) returns (ListAccessInfoResponse);
 
     rpc CreateAccess(CreateAccessRequest) returns (google.protobuf.Empty);
     rpc UpdateAccess(UpdateAccessRequest) returns (google.protobuf.Empty);

--- a/services.proto
+++ b/services.proto
@@ -22,7 +22,7 @@ service EcdarBackend {
 service EcdarApi {
     rpc GetModel(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc CreateModel(CreateModelRequest) returns (CreateModelResponse);
-    rpc UpdateModel(google.protobuf.Empty) returns (google.protobuf.Empty);
+    rpc UpdateModel(UpdateModelRequest) returns (google.protobuf.Empty);
     rpc DeleteModel(DeleteModelRequest) returns (google.protobuf.Empty);
     rpc ListModelsInfo(google.protobuf.Empty) returns (google.protobuf.Empty);
 

--- a/services.proto
+++ b/services.proto
@@ -34,5 +34,5 @@ service EcdarApi {
 
 service EcdarApiAuth {
     rpc GetAuthToken(GetAuthTokenRequest) returns (GetAuthTokenResponse);
-    rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
+    rpc CreateUser(CreateUserRequest) returns (google.protobuf.Empty);
 }

--- a/services.proto
+++ b/services.proto
@@ -22,17 +22,20 @@ service EcdarBackend {
 service EcdarApi {
     rpc GetModel(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc CreateModel(google.protobuf.Empty) returns (google.protobuf.Empty);
-    rpc CreateAccess(CreateAccessRequest) returns (google.protobuf.Empty);
-    rpc UpdateUser(UpdateUserRequest) returns (google.protobuf.Empty);
     rpc UpdateModel(google.protobuf.Empty) returns (google.protobuf.Empty);
-    rpc UpdateAccess(UpdateAccessRequest) returns (google.protobuf.Empty);
-    rpc UpdateQuery(UpdateQueryRequest) returns (google.protobuf.Empty);
-    rpc DeleteUser(google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc DeleteModel(google.protobuf.Empty) returns (google.protobuf.Empty);
-    rpc DeleteQuery(DeleteQueryRequest) returns (google.protobuf.Empty);
-    rpc DeleteAccess(DeleteAccessRequest) returns (google.protobuf.Empty);
     rpc ListModelsInfo(google.protobuf.Empty) returns (google.protobuf.Empty);
+
+    rpc CreateAccess(CreateAccessRequest) returns (google.protobuf.Empty);
+    rpc UpdateAccess(UpdateAccessRequest) returns (google.protobuf.Empty);
+    rpc DeleteAccess(DeleteAccessRequest) returns (google.protobuf.Empty);
+
+    rpc UpdateUser(UpdateUserRequest) returns (google.protobuf.Empty);
+    rpc DeleteUser(google.protobuf.Empty) returns (google.protobuf.Empty);
+
     rpc CreateQuery(CreateQueryRequest) returns (google.protobuf.Empty);
+    rpc UpdateQuery(UpdateQueryRequest) returns (google.protobuf.Empty);
+    rpc DeleteQuery(DeleteQueryRequest) returns (google.protobuf.Empty);
 }
 
 service EcdarApiAuth {


### PR DESCRIPTION
Implemented two new services, their methods and their Message types.

- Added service `EcdarApi` with gRPC methods:
  - `GetProject(GetProjectRequest) returns (GetProjectResponse)`
  - `CreateProject(CreateProjectRequest) returns (CreateProjectResponse)`
  - `UpdateProject(UpdateProjectRequest) returns (google.protobuf.Empty)`
  - `DeleteProject(DeleteProjectRequest) returns (google.protobuf.Empty)`
  - `ListProjectsInfo(google.protobuf.Empty) returns (ListProjectsInfoResponse)`
  - `ListAccessInfo(ListAccessInfoRequest) returns (ListAccessInfoResponse)`
  - `CreateAccess(CreateAccessRequest) returns (google.protobuf.Empty)`
  - `UpdateAccess(UpdateAccessRequest) returns (google.protobuf.Empty)`
  - `DeleteAccess(DeleteAccessRequest) returns (google.protobuf.Empty)`
  - `UpdateUser(UpdateUserRequest) returns (google.protobuf.Empty)`
  - `DeleteUser(google.protobuf.Empty) returns (google.protobuf.Empty)`
  - `GetUsers(GetUsersRequest) returns (GetUsersResponse)`
  - `CreateQuery(CreateQueryRequest) returns (google.protobuf.Empty)`
  - `UpdateQuery(UpdateQueryRequest) returns (google.protobuf.Empty)`
  - `DeleteQuery(DeleteQueryRequest) returns (google.protobuf.Empty)`
  - `SendQuery(SendQueryRequest) returns (SendQueryResponse)`
  - `DeleteSession(google.protobuf.Empty) returns (google.protobuf.Empty)`

- Added service `EcdarApiAuth` with gRPC methods:
  - `GetAuthToken(GetAuthTokenRequest) returns (GetAuthTokenResponse)`
  - `CreateUser(CreateUserRequest) returns (google.protobuf.Empty)`
  - `Endpoints(google.protobuf.Empty) returns (EndpointsResponse)`